### PR TITLE
Rename `webview` function to `webview_run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Look at the example `webview-example.c`.
 
 int main() {
   /* Open Lua in a 800x600 resizable window */
-  webview("Minimal webview example", "https://www.lua.org", 800, 600, 1);
+  webview_run("Minimal webview example", "https://www.lua.org", 800, 600, 1);
   return 0;
 }
 ```

--- a/webview-example.c
+++ b/webview-example.c
@@ -5,6 +5,6 @@
 int main(int argc, char *argv[]) {
   /* Open Lua in a 800x600 resizable window */
   /* The URL can be passed in argument, such as https://www.whatsmyua.info/ */
-  webview("Minimal webview example", argc > 1 ? argv[1] : "https://www.lua.org", 800, 600, 1);
+  webview_run("Minimal webview example", argc > 1 ? argv[1] : "https://www.lua.org", 800, 600, 1);
   return 0;
 }

--- a/webview.h
+++ b/webview.h
@@ -92,7 +92,7 @@ struct webview_priv {
 #error "Define one of: WEBVIEW_GTK, WEBVIEW_COCOA or WEBVIEW_WINAPI"
 #endif
 
-struct webview;
+typedef struct webview webview;
 
 typedef void (*webview_external_invoke_cb_t)(struct webview *w,
                                              const char *arg);
@@ -127,13 +127,15 @@ enum webview_dialog_flag {
 
 typedef void (*webview_dispatch_fn)(struct webview *w, void *arg);
 
+typedef struct webview_dispatch_arg webview_dispatch_arg;
+
 struct webview_dispatch_arg {
   webview_dispatch_fn fn;
   struct webview *w;
   void *arg;
 };
 
-WEBVIEW_API int webview(const char *title, const char *url, int width,
+WEBVIEW_API int webview_run(const char *title, const char *url, int width,
                         int height, int resizable);
 
 WEBVIEW_API int webview_init(struct webview *w);
@@ -180,7 +182,7 @@ static const char *webview_check_url(const char *url) {
   return url;
 }
 
-WEBVIEW_API int webview(const char *title, const char *url, int width,
+WEBVIEW_API int webview_run(const char *title, const char *url, int width,
                         int height, int resizable) {
   struct webview webview;
   memset(&webview, 0, sizeof(webview));


### PR DESCRIPTION
This fixes #1 

The name `webview_run` is taken from the original webview repository.

It also adds typedefs for `webview` and `webview_dispatch_arg`, to make straightforward to use them in C code.