### PR TITLE
Declare `webview_priv` only in implementation

### DIFF
--- a/webview.h
+++ b/webview.h
@@ -38,59 +38,7 @@ extern "C" {
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(WEBVIEW_GTK)
-#include <JavaScriptCore/JavaScript.h>
-#include <gtk/gtk.h>
-#include <webkit2/webkit2.h>
-
-struct webview_priv {
-  GtkWidget *window;
-  GtkWidget *scroller;
-  GtkWidget *webview;
-  GtkWidget *inspector_window;
-  GAsyncQueue *queue;
-  int ready;
-  int js_busy;
-  int should_exit;
-};
-#elif defined(WEBVIEW_WINAPI)
-#define CINTERFACE
-#include <windows.h>
-
-#include <commctrl.h>
-#include <exdisp.h>
-#include <mshtmhst.h>
-#include <mshtml.h>
-#include <shobjidl.h>
-
-#include <stdio.h>
-
-typedef struct webview2_struct webview2;
-
-struct webview_priv {
-  HWND hwnd;
-  IOleObject **browser;
-  BOOL is_fullscreen;
-  DWORD saved_style;
-  DWORD saved_ex_style;
-  RECT saved_rect;
-  webview2 *webview2;
-};
-#elif defined(WEBVIEW_COCOA)
-#include <objc/objc-runtime.h>
-#include <CoreGraphics/CoreGraphics.h>
-#include <limits.h>
-
-struct webview_priv {
-  id pool;
-  id window;
-  id webview;
-  id windowDelegate;
-  int should_exit;
-};
-#else
-#error "Define one of: WEBVIEW_GTK, WEBVIEW_COCOA or WEBVIEW_WINAPI"
-#endif
+struct webview_priv;
 
 struct webview;
 
@@ -105,7 +53,7 @@ struct webview {
   int resizable;
   int debug;
   webview_external_invoke_cb_t external_invoke_cb;
-  struct webview_priv priv;
+  struct webview_priv *priv;
   void *userdata;
 };
 
@@ -177,6 +125,9 @@ WEBVIEW_API void webview_print_log(const char *s);
 
 #ifdef WEBVIEW_IMPLEMENTATION
 #undef WEBVIEW_IMPLEMENTATION
+
+#include <stdarg.h>
+#include <stdio.h>
 
 WEBVIEW_API int webview(const char *title, const char *url, int width,
                         int height, int resizable) {
@@ -256,6 +207,8 @@ WEBVIEW_API int webview_inject_css(struct webview *w, const char *css) {
 
 #include "webview-cocoa.c"
 
+#else
+#error "Define one of: WEBVIEW_GTK, WEBVIEW_COCOA or WEBVIEW_WINAPI"
 #endif
 
 #endif /* WEBVIEW_IMPLEMENTATION */


### PR DESCRIPTION
This PR fixes #3, it moves declaration of `webview_priv` to implementation only, allowing to skip including platform headers when not implementing. This is done by using a pointer and `malloc` in `priv` field.

I've tested on Linux/Windows and not in MacOS, nevertheless I've changed the Cocoa code.
